### PR TITLE
Refactor: Remove .html extensions from URLs

### DIFF
--- a/booking.js
+++ b/booking.js
@@ -160,7 +160,7 @@ document.addEventListener('DOMContentLoaded', function() {
           haircutType: serviceType
         };
         localStorage.setItem('appointmentDetails', JSON.stringify(appointmentDetails));
-        window.location.href = 'confirmation.html';
+        window.location.href = '/confirmation/';
       }
     } catch (err) {
       showValidationError(null, 'התרחשה שגיאה בקביעת התור. אנא נסו שוב מאוחר יותר.');

--- a/booking/index.html
+++ b/booking/index.html
@@ -9,13 +9,13 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-rtl/4.5.2-1/bootstrap-rtl.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.9.0/css/bootstrap-datepicker.min.css">
     <link rel="stylesheet" href="https://kit.fontawesome.com/a076d05399.css">
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
     <div class="d-flex flex-column min-vh-100">
         <nav class="navbar navbar-expand-lg navbar-light bg-light">
-            <a class="navbar-brand" href="index.html">
-                <img src="images/logo.png" alt="לוגו המספרה" height="60">
+            <a class="navbar-brand" href="/">
+                <img src="../images/logo.png" alt="לוגו המספרה" height="60">
             </a>
             <button class="navbar-toggler" type="button" data-toggle="collapse"
                     data-target="#navbarNav" aria-controls="navbarNav"
@@ -25,13 +25,13 @@
             <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">בית</a>
+                        <a class="nav-link" href="/">בית</a>
                     </li>
                     <li class="nav-item active">
                         <a class="nav-link" href="#">קביעת תור</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">צרו קשר</a>
+                        <a class="nav-link" href="/contact/">צרו קשר</a>
                     </li>
                 </ul>
             </div>
@@ -156,7 +156,7 @@
 
             <div class="contact-page-link text-center mt-4">
                 <p>צריכים מידע נוסף?</p>
-                <a href="contact.html" class="btn btn-info">
+                <a href="/contact/" class="btn btn-info">
                     <i class="fas fa-info-circle"></i> מעבר לעמוד צרו קשר
                 </a>
             </div>
@@ -171,6 +171,6 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.9.0/js/bootstrap-datepicker.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.9.0/locales/bootstrap-datepicker.he.min.js"></script>
-    <script src="booking.js"></script>
+    <script src="../booking.js"></script>
 </body>
 </html>

--- a/confirmation/index.html
+++ b/confirmation/index.html
@@ -12,14 +12,14 @@
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-rtl/4.5.2-1/bootstrap-rtl.min.css">
     <!-- CSS מותאם אישית -->
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
     <div class="d-flex flex-column min-vh-100">
         <!-- תפריט ניווט -->
         <nav class="navbar navbar-expand-lg navbar-light bg-light">
-            <a class="navbar-brand" href="index.html">
-                <img src="images/logo.png" alt="לוגו המספרה" height="60">
+            <a class="navbar-brand" href="/">
+                <img src="../images/logo.png" alt="לוגו המספרה" height="60">
             </a>
             <button class="navbar-toggler" type="button" data-toggle="collapse"
                     data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false"
@@ -30,13 +30,13 @@
                  id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">בית</a>
+                        <a class="nav-link" href="/">בית</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="booking.html">קביעת תור</a>
+                        <a class="nav-link" href="/booking/">קביעת תור</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">צרו קשר</a>
+                        <a class="nav-link" href="/contact/">צרו קשר</a>
                     </li>
                 </ul>
             </div>
@@ -52,7 +52,7 @@
             <p>נשמח לראותך ב-HairFormation.</p>
             <!-- הודעת הספירה לאחור -->
             <p id="redirectMessage">תועבר לעמוד הבית בעוד <span id="countdown">5</span> שניות.</p>
-            <a href="index.html" class="btn btn-primary mt-4">חזרה לדף הבית</a>
+            <a href="/" class="btn btn-primary mt-4">חזרה לדף הבית</a>
         </div>
 
         <!-- Footer -->
@@ -120,7 +120,7 @@
             countdownElement.textContent = countdown;
             if (countdown <= 0) {
                 clearInterval(countdownInterval);
-                window.location.href = 'index.html';
+                window.location.href = '/';
             }
         }, 1000); // עדכון כל שנייה (1000 מילישניות)
     </script>

--- a/contact/index.html
+++ b/contact/index.html
@@ -14,14 +14,14 @@
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-rtl/4.5.2-1/bootstrap-rtl.min.css">
     <!-- CSS מותאם אישית -->
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="../styles.css">
 </head>
 <body>
     <div class="d-flex flex-column min-vh-100">
         <!-- תפריט ניווט -->
         <nav class="navbar navbar-expand-lg navbar-light bg-light">
-            <a class="navbar-brand" href="index.html">
-                <img src="images/logo.png" alt="לוגו המספרה" height="60">
+            <a class="navbar-brand" href="/">
+                <img src="../images/logo.png" alt="לוגו המספרה" height="60">
             </a>
             <button class="navbar-toggler" type="button" data-toggle="collapse"
                     data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false"
@@ -32,10 +32,10 @@
                  id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link" href="index.html">בית</a>
+                        <a class="nav-link" href="/">בית</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="booking.html">קביעת תור</a>
+                        <a class="nav-link" href="/booking/">קביעת תור</a>
                     </li>
                     <li class="nav-item active">
                         <a class="nav-link" href="#">צרו קשר</a>
@@ -86,10 +86,10 @@
                 <div class="social-media">
                     <p>הצטרפו אלינו ברשתות החברתיות:</p>
                     <a href="https://www.facebook.com/HairformationID" target="_blank">
-                        <img src="images/facebook.png" alt="פייסבוק" class="social-icon">
+                        <img src="../images/facebook.png" alt="פייסבוק" class="social-icon">
                     </a>
                     <a href="https://www.instagram.com/hair_formation" target="_blank">
-                        <img src="images/instagram.png" alt="אינסטגרם" class="social-icon">
+                        <img src="../images/instagram.png" alt="אינסטגרם" class="social-icon">
                     </a>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <div class="d-flex flex-column min-vh-100">
         <!-- תפריט ניווט -->
         <nav class="navbar navbar-expand-lg navbar-light bg-light">
-            <a class="navbar-brand" href="index.html">
+            <a class="navbar-brand" href="/">
                 <!-- Removed height="60" so the CSS can control size -->
                 <img src="images/logo.png" alt="לוגו המספרה">
             </a>
@@ -47,13 +47,13 @@
             >
                 <ul class="navbar-nav">
                     <li class="nav-item active">
-                        <a class="nav-link" href="#">בית</a>
+                        <a class="nav-link" href="/">בית</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="booking.html">קביעת תור</a>
+                        <a class="nav-link" href="/booking/">קביעת תור</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="contact.html">צרו קשר</a>
+                        <a class="nav-link" href="/contact/">צרו קשר</a>
                     </li>
                 </ul>
             </div>
@@ -64,7 +64,7 @@
             <div class="overlay">
                 <h1>HairFormation</h1>
                 <p>התספורות הטובות ביותר</p>
-                <a href="booking.html" class="btn btn-primary btn-lg">קבעו תור עכשיו</a>
+                <a href="/booking/" class="btn btn-primary btn-lg">קבעו תור עכשיו</a>
             </div>
         </header>
 


### PR DESCRIPTION
I've restructured your website files to remove .html from URLs for a cleaner look.

Here's what I did:
- I moved page.html to page/index.html for your booking, confirmation, and contact pages.
- I updated all internal navigation links in your HTML files to use the new path structure (e.g., /booking/ instead of booking.html).
- I updated your JavaScript redirects to use the new paths.
- I adjusted relative asset paths (CSS, JS, images) within the new subdirectories to correctly point to the root locations of these assets.
- I ensured your root index.html links are updated to "/" for consistency.